### PR TITLE
Feat: nuevo endPoint para editar la referencia de una solicitud

### DIFF
--- a/controllers/solicitud_evaluacion.go
+++ b/controllers/solicitud_evaluacion.go
@@ -1,9 +1,12 @@
 package controllers
 
 import (
+	"encoding/json"
+
 	"github.com/astaxie/beego"
 	"github.com/udistrital/sga_actualizacion_dato_mid/services"
 	"github.com/udistrital/utils_oas/errorhandler"
+	"github.com/udistrital/utils_oas/requestresponse"
 )
 
 // SolicitudEvaluacionController ...
@@ -154,6 +157,33 @@ func (c *SolicitudEvaluacionController) PutSolicitudEvaluacion() {
 	idSolicitud := c.Ctx.Input.Param(":id")
 
 	respuesta := services.SolicitudEvaluacionPut(idSolicitud)
+
+	c.Ctx.Output.SetStatus(respuesta.Status)
+	c.Data["json"] = respuesta
+	c.ServeJSON()
+}
+
+// PutSolicitud...
+// @Title PutSolicitud
+// @Description Modifica una solicitud existente
+// @Param   body        body    {}  true        "body Modificar solicitud content"
+// @Success 200 {}
+// @Failure 403 body is empty
+// @router /:id_solicitud [put]
+func (c *SolicitudEvaluacionController) PutSolicitudReferencia() {
+	defer errorhandler.HandlePanic(&c.Controller)
+
+	idSolicitud := c.Ctx.Input.Param(":id_solicitud")
+
+	var referencia map[string]interface{}
+	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &referencia); err != nil {
+		c.Ctx.Output.SetStatus(400)
+		c.Data["json"] = requestresponse.APIResponseDTO(false, 400, nil, "Error en el formato de la solicitud")
+		c.ServeJSON()
+		return
+	}
+
+	respuesta := services.PutSolicitudReferencia(idSolicitud, referencia)
 
 	c.Ctx.Output.SetStatus(respuesta.Status)
 	c.Data["json"] = respuesta

--- a/routers/commentsRouter_controllers.go
+++ b/routers/commentsRouter_controllers.go
@@ -36,6 +36,15 @@ func init() {
 
     beego.GlobalControllerRouter["github.com/udistrital/sga_actualizacion_dato_mid/controllers:SolicitudEvaluacionController"] = append(beego.GlobalControllerRouter["github.com/udistrital/sga_actualizacion_dato_mid/controllers:SolicitudEvaluacionController"],
         beego.ControllerComments{
+            Method: "PutSolicitudReferencia",
+            Router: "/:id_solicitud",
+            AllowHTTPMethods: []string{"put"},
+            MethodParams: param.Make(),
+            Filters: nil,
+            Params: nil})
+
+    beego.GlobalControllerRouter["github.com/udistrital/sga_actualizacion_dato_mid/controllers:SolicitudEvaluacionController"] = append(beego.GlobalControllerRouter["github.com/udistrital/sga_actualizacion_dato_mid/controllers:SolicitudEvaluacionController"],
+        beego.ControllerComments{
             Method: "GetAllSolicitudActualizacionDatos",
             Router: "/estados/:id_estado_tipo_solicitud",
             AllowHTTPMethods: []string{"get"},

--- a/services/solicitud_evaluacion_services.go
+++ b/services/solicitud_evaluacion_services.go
@@ -578,11 +578,27 @@ func solicitudTipoGetActualizacion(Solicitudes []map[string]interface{}, i int, 
 func ManejoSolicitudesGetActualizacion(Solicitudes *[]map[string]interface{}, id_persona string, respuesta *[]map[string]interface{}, TipoSolicitud *map[string]interface{}, Estado *map[string]interface{}, errorGetAll *bool, alertas *[]interface{}, alerta *models.Alert, resultado *map[string]interface{}) interface{} {
 	errSolicitud := request.GetJson("http://"+beego.AppConfig.String("SolicitudDocenteService")+"solicitante?query=TerceroId:"+id_persona+"&sortby=Id&order=asc&limit=0", Solicitudes)
 	if errSolicitud == nil {
+
 		if *Solicitudes != nil && fmt.Sprintf("%v", (*Solicitudes)[0]) != "map[]" {
+			// Filtrar solicitudes activas de actualización de datos
+			var solicitudesActivas []map[string]interface{}
+			for _, solicitud := range *Solicitudes {
+				if solicitudId, ok := solicitud["SolicitudId"].(map[string]interface{}); ok {
+					if activo, ok := solicitudId["Activo"].(bool); ok && activo {
+						solicitudesActivas = append(solicitudesActivas, solicitud)
+					}
+				}
+			}
+
+			if len(solicitudesActivas) == 0 {
+				ManejoError(alerta, alertas, "No active data found", errorGetAll)
+				return map[string]interface{}{"Response": *alerta}
+			}
+
 			var data interface{}
-			*respuesta = make([]map[string]interface{}, len(*Solicitudes))
-			for i := 0; i < len(*Solicitudes); i++ {
-				data = solicitudTipoGetActualizacion(*Solicitudes, i, id_persona, respuesta, TipoSolicitud, Estado, errorGetAll, alertas, alerta)
+			*respuesta = make([]map[string]interface{}, len(solicitudesActivas))
+			for i := 0; i < len(solicitudesActivas); i++ {
+				data = solicitudTipoGetActualizacion(solicitudesActivas, i, id_persona, respuesta, TipoSolicitud, Estado, errorGetAll, alertas, alerta)
 				if data != nil {
 					return data
 				}

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -185,6 +185,32 @@
                         "description": "body is empty"
                     }
                 }
+            },
+            "put": {
+                "tags": [
+                    "solicitudes"
+                ],
+                "description": "Modifica una solicitud existente",
+                "operationId": "SolicitudEvaluacionController.PutSolicitud",
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "body Modificar solicitud content",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/{}"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "{}"
+                    },
+                    "403": {
+                        "description": "body is empty"
+                    }
+                }
             }
         },
         "/solicitudes/{id}/evaluacion": {


### PR DESCRIPTION
- Nuevo endPoint para editar la referencia de una solicitud unicamente con el estado "Solicitud generada".
- Correccion de bug en formato de fecha al guardar la nueva identificacion del tercero.
- Ajuste de ids en el flujo para gestionar los estados de las solicitudes.
- Eliminar logica para convertir que generaba una nueva solicitud con estado "Rectificar", ahora la crea con estado "Solicitud generada" y desactiva la anterior solicitud (solicitudPadre)
---
udistrital/sga_documentacion#287